### PR TITLE
set mesh local to scene

### DIFF
--- a/addons/progress_bar_3d/progress_bar_3d.gd
+++ b/addons/progress_bar_3d/progress_bar_3d.gd
@@ -117,6 +117,7 @@ func _enter_tree() -> void:
 		mesh.size = Vector2(1.0, .1)
 		var mat := ShaderMaterial.new()
 		mesh.material = mat
+		mesh.resource_local_to_scene = true
 		var shader: Shader = load("res://addons/progress_bar_3d/progress_bar_3d.gdshader").duplicate()
 		mat.shader = shader
 	else:


### PR DESCRIPTION
I was running into issues using the progress bar in multiple places, the values were being shared across all instances of the progress bar!

Turns out it is because the sub-resource, the quad mesh, is not set to "local to scene". This PR enables that setting, allowing a unique instance of the mesh and shader for each usage of the ProgressBar.